### PR TITLE
Adjust README to show current plugin name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Simple clojure coverage tool. Currently requires clojure 1.4.
 
 * Installation
 
-$ (cd cloverage && lein install) && (cd cloverage-lein-plugin && lein install)
+$ (cd cloverage && lein install) && (cd lein-cloverage && lein install)
 
-Then add [cloverage-lein-plugin "1.0.0-SNAPSHOT"] to :plugins in your
+Then add [lein-cloverage "1.0.0-SNAPSHOT"] to :plugins in your
 .lein/profiles.clj
 
 * Usage


### PR DESCRIPTION
Currently the README uses what looks like an old name.
