### PR TITLE
IllegalArgumentException: No matching field found: toPath for class java.io.File when running cloverage Edit 

### DIFF
--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -97,24 +97,43 @@
   (.replace s " " "&nbsp;"))
 
 ;; Java 7 has a much nicer API, but this supports Java 6.
-(defn relative-path [file base-dir]
-  ^{:doc "Return the path to file relative to base-dir. file is a java.io.File."}
-  (let [path (.getAbsolutePath file)
-        base (.getAbsolutePath (java.io.File. base-dir))]
-    (drop (count base) path)))
+(defn relative-path [target-dir base-dir]
+  ^{:doc "Return the path to target-dir relative to base-dir.
+          Both arguments are java.io.File"}
+  (loop [target-file (.getAbsoluteFile target-dir)
+         base-file   (.getAbsoluteFile base-dir)
+         postpend    ""
+         prepend     ""]
+    (let [target-path (.getAbsolutePath target-file)
+          base-path   (.getAbsolutePath base-file)]
+      (cond
+        (= base-path target-path)
+        (apply str prepend postpend)
+
+        (> (count base-path)
+           (count target-path))
+        (recur target-file (.getParentFile base-file) postpend (str prepend "../"))
+
+        :else
+        (let [new-target (.getParentFile target-file)
+              suffix     (subs target-path
+                               (count (.getAbsolutePath new-target)))]
+          (recur new-target base-file
+                 (str (subs suffix 1) "/" postpend)
+                 prepend))))))
 
 (defn html-report [out-dir forms]
   (copy (resource-reader "coverage.css") (File. out-dir "coverage.css"))
   (stats-report (File. out-dir "coverage.txt") forms)
   (doseq [[rel-file file-forms] (group-by :file forms)]
     (let [file     (File. out-dir (str rel-file ".html"))
-          rootpath (relative-path file out-dir)
+          rootpath (relative-path (File. out-dir) (.getParentFile file))
           ]
       (.mkdirs (.getParentFile file))
       (with-out-writer file
         (println "<html>")
         (println " <head>")
-        (printf "  <link rel=\"stylesheet\" href=\"%s/coverage.css\"/>" rootpath)
+        (printf "  <link rel=\"stylesheet\" href=\"%scoverage.css\"/>" rootpath)
         (println "  <title>" rel-file "</title>")
         (println " </head>")
         (println " <body>")
@@ -149,13 +168,12 @@
   (format "<td class=\"with-number\">%s</td>" content))
 
 (defn html-summary [out-dir forms]
-  (let [index (File. out-dir "index.html")
-        rootpath (relative-path index out-dir)]
-    (.mkdirs (.getParentFile index))
+  (let [index (File. out-dir "index.html")]
+    (.mkdirs (File. out-dir))
     (with-out-writer index
       (println "<html>")
       (println " <head>")
-      (printf  "  <link rel=\"stylesheet\" href=\"./%s/coverage.css\"/>" rootpath)
+      (println "  <link rel=\"stylesheet\" href=\"./coverage.css\"/>")
       (println "  <title>Coverage Summary</title>")
       (println " </head>")
       (println " <body>")

--- a/cloverage/test/cloverage/test_report.clj
+++ b/cloverage/test/cloverage/test_report.clj
@@ -1,0 +1,16 @@
+(ns cloverage.test-report
+  (:import java.io.File)
+  (:use clojure.test
+        cloverage.report))
+
+(deftest test-relative-path
+  (is (= "child/" (relative-path (File. "parent/child/") (File. "parent/"))))
+  (is (= "parent/child/"
+         (relative-path (File. "shared" "parent/child/") (File. "shared/"))))
+  (is (= "parent/long dir name/"
+         (relative-path (File. "shared/parent/long dir name") (File. "shared"))))
+  (is (= "../dir2/child/"
+         (relative-path (File. "dir2/child/") (File. "dir"))))
+  (is (= "dir/" (relative-path (File. "/tmp/dir/") (File. "/tmp"))))
+  (is (= "" (relative-path (File. "/") (File. "/"))))
+  (is (= "" (relative-path (File. "dir/file/") (File. "dir/file/")))))


### PR DESCRIPTION
That's because toPath doesn't exist in JDK 1.6 (and nothing indicates that 1.7's required).

Now with our own relative path.
