### PR TITLE
Read while evalling

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -131,14 +131,12 @@
       (println "Loading namespaces: " namespaces)
       (println "Test namespaces: " test-nses)
       (doseq [namespace (in-dependency-order (map symbol namespaces))]
-        (let [file          (resource-path namespace)
-              ns-forms      (forms namespace)]
-          (binding [*instrumented-ns* namespace]
-            (if nops?
-              (instrument nop ns-forms file)
-              (instrument track-coverage ns-forms file))))
+        (binding [*instrumented-ns* namespace]
+          (if nops?
+            (instrument nop namespace)
+            (instrument track-coverage namespace)))
         (println "Loaded " namespace " .")
-        (mark-loaded namespace)) 
+        (mark-loaded namespace))
         ;; mark the ns as loaded
       (println "Instrumented namespaces.")
       (when-not (empty? test-nses)

--- a/cloverage/test/cloverage/sample/read_eval_sample.clj
+++ b/cloverage/test/cloverage/sample/read_eval_sample.clj
@@ -1,9 +1,10 @@
 (ns cloverage.sample.read-eval-sample)
 
-(def ^:dynamic dynamic-symbol)
-(defmacro with-bound-dynamic-symbol
+(def ^:dynamic *dynamic-var*)
+
+(defmacro with-bound-dynamic-var
   [& body]
-  `(binding [dynamic-symbol true]
+  `(binding [*dynamic-var* true]
      (do ~@body)))
 
 (defn do-something [arg]

--- a/cloverage/test/cloverage/sample/read_eval_sample.clj
+++ b/cloverage/test/cloverage/sample/read_eval_sample.clj
@@ -1,0 +1,10 @@
+(ns cloverage.sample.read-eval-sample)
+
+(def ^:dynamic dynamic-symbol)
+(defmacro with-bound-dynamic-symbol
+  [& body]
+  `(binding [dynamic-symbol true]
+     (do ~@body)))
+
+(defn do-something [arg]
+  (with-bound-dynamic-symbol arg))

--- a/cloverage/test/cloverage/test_coverage.clj
+++ b/cloverage/test/cloverage/test_coverage.clj
@@ -144,8 +144,7 @@
 
 (deftest test-instrument-gets-lines
   (instrument track-coverage
-              (forms 'cloverage.sample)
-              (resource-path 'cloverage.sample))
+              'cloverage.sample)
   (let [cov @*covered*
         found (find-form cov '(+ 1 2))]
     #_(with-out-writer "out/foo"

--- a/cloverage/test/cloverage/test_instrument.clj
+++ b/cloverage/test/cloverage/test_instrument.clj
@@ -12,9 +12,6 @@
    #{:sets :should :work}
    '(do :expression)])
 
-(deftest tree-walk-preserves-forms
-  (is (= simple-forms (instrument no-instr simple-forms))))
-
 (deftest wrap-preserves-value
   (doseq [simple-expr simple-forms]
     (is (= simple-expr (wrap no-instr 0 simple-expr)))

--- a/cloverage/test/cloverage/test_instrument.clj
+++ b/cloverage/test/cloverage/test_instrument.clj
@@ -17,6 +17,10 @@
     (is (= simple-expr (wrap no-instr 0 simple-expr)))
     (is (= (eval simple-expr) (eval (wrap nop 0 simple-expr))))))
 
+(deftest correctly-resolves-macro-symbols
+  ;; simply ensure that instrumentation succeeds without errors
+  (is (instrument no-instr 'cloverage.sample.read-eval-sample)))
+
 (deftest test-form-type
   (is (= :atomic (form-type 1)))
   (is (= :atomic (form-type "foo")))


### PR DESCRIPTION
Clojure compiler evaluates forms as it reads them in, and uses that when parsing syntax quotes to resolve symbol namespaces. If we read all forms before evaluating any, symbols in syntax quotes within the forms will have wrong namespaces, and break anything that uses them.

Therefore we will evaluate each form before reading the next one.
