### PR TITLE
Should use a default output location

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -74,7 +74,8 @@
               @col))))
 
 (defn parse-args [args]
-  (cli args ["-o" "--output"]
+  (cli args
+       ["-o" "--output" "Output directory." :default "target/coverage"]
        ["--[no-]text"
         "Produce a text report." :default false]
        ["--[no-]html"
@@ -150,7 +151,7 @@
             (html-summary output stats)
             (html-report output stats))
           (when raw?
-            (raw-report output stats @*covered*))))
-      (println "Produced output.")))
+            (raw-report output stats @*covered*)))
+        (println "Produced output in" (.getAbsolutePath (File. output)) "."))))
   (shutdown-agents)
   nil)


### PR DESCRIPTION
If you have no `-o`, running coverage will generate no output.

It should instead use `target/coverage` as a default and, regardless of `-o` or not, tell you where it put the coverage.
