### PR TITLE
Doesn't mark cond as fully covered

### DIFF
--- a/cloverage/src/cloverage/sample.clj
+++ b/cloverage/src/cloverage/sample.clj
@@ -95,3 +95,12 @@
   ;; permutation is partially covered
   (is (not (permutation? "foo" "foobar"))))
 
+(defn fully-covered-cond
+  [n]
+  (cond
+    (zero? n) :zero
+    :else     :nonzero))
+
+(deftest test-fully-covered-cond
+  (is (= :zero (fully-covered-cond 0)))
+  (is (= :nonzero (fully-covered-cond 1))))


### PR DESCRIPTION
Given a cond where every test and every expr (including `:else` and its expr) is marked as covered, the "head" line is marked as only partially covered.
