### PR TITLE
Usability fixes.

### DIFF
--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -212,7 +212,7 @@
                                   [:partial partial]
                                   [:not-covered missed]))
           (println (td-num (format "%.2f %%" (/ (* 100.0 (+ covered partial))
-                                                lines))))
+                                                instrd))))
           (println
             (apply str (map td-num [lines blank instrd])))
           (println "</tr>")

--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -12,9 +12,12 @@
        ".clj"))
 
 (defn resource-reader [resource]
-  (tprnl (seq (.getURLs (java.lang.ClassLoader/getSystemClassLoader))))
-  (InputStreamReader.
-   (.getResourceAsStream (clojure.lang.RT/baseLoader) resource)))
+  (if-let [reader (InputStreamReader.
+                    (.getResourceAsStream
+                      (clojure.lang.RT/baseLoader)
+                      resource))]
+    reader
+    (throw (InvalidArgumentException. (str "Cannot find resource" resource)))))
 
 (defn form-reader [ns-symbol]
   (LineNumberingPushbackReader. (resource-reader (resource-path ns-symbol))))

--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -1,6 +1,7 @@
 (ns cloverage.source
-  (:import [java.io InputStreamReader]
-           [clojure.lang LineNumberingPushbackReader])
+  (:import java.io.InputStreamReader
+           java.lang.IllegalArgumentException
+           clojure.lang.LineNumberingPushbackReader)
   (:use    [cloverage.debug]))
 
 (defn resource-path
@@ -12,12 +13,11 @@
        ".clj"))
 
 (defn resource-reader [resource]
-  (if-let [reader (InputStreamReader.
-                    (.getResourceAsStream
+  (if-let [resource (.getResourceAsStream
                       (clojure.lang.RT/baseLoader)
-                      resource))]
-    reader
-    (throw (InvalidArgumentException. (str "Cannot find resource" resource)))))
+                      resource)]
+    (InputStreamReader. resource)
+    (throw (IllegalArgumentException. (str "Cannot find resource " resource)))))
 
 (defn form-reader [ns-symbol]
   (LineNumberingPushbackReader. (resource-reader (resource-path ns-symbol))))


### PR DESCRIPTION
Show line coverage % per instrumented lines, not total lines.
Fail cleaner than a NPE when a source file can't be found.
